### PR TITLE
Fix missing ROS_MASTER_URI on master deployment

### DIFF
--- a/k8s/master-deployment.yaml
+++ b/k8s/master-deployment.yaml
@@ -27,6 +27,9 @@ spec:
         ports:
         - containerPort: 11311
           name: roscoreport
+        env:
+          - name: ROS_MASTER_URI
+            value: http://0.0.0.0:11311
 
 ---
 


### PR DESCRIPTION
# Change
This PR solves an error while deploying the ROS application on Kubernetes

The `ROS_MASTER_URI` was not configured on the master node, and therefore a new env var was added to the master deployment.

# Issue
While launching the ROS master deployment on Kubernetes, the following error was returned:

``
/opt/ros/melodic/etc/catkin/profile.d/10.roslaunch.sh: line 3: ROS_MASTER_URI: unbound variable
``